### PR TITLE
ASI-302 Configurable MARC files directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@
 /config/secrets.yml
 /config/archivesspace.yml
 /config/folio.yml
+/config/folio_sync.yml
 
 # Ignore Mac system files
 .DS_Store

--- a/Capfile
+++ b/Capfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load DSL and set up stages
 require 'capistrano/setup'
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ rails folio_sync:aspace_to_folio:run
 ## Tasks
 
 ### `folio_sync:aspace_to_folio:process_marc_xml`
-This task allows you to test the processing of a MARC XML file for a specific `bib_id`. It reads the MARC XML file from the `tmp/marc_files` directory, processes it, and applies the necessary transformations.
+This task allows you to test the processing of a MARC XML file for a specific `bib_id`. It reads the MARC XML file from the `marc_download_directory` specified in `folio_sync.yml` file, processes it, and applies the necessary transformations.
 
 #### Usage:
 ```bash

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,7 @@ module FolioSync
   class Application < Rails::Application
     config.archivesspace = config_for(:archivesspace)
     config.folio = config_for(:folio)
+    config.folio_sync = config_for(:folio_sync)
 
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0

--- a/config/environments/deployed.rb
+++ b/config/environments/deployed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # deployed.rb is for shared configuration -- it is loaded by each env config file
 # This is copied from the rails generated environments/production.rb file
 # bibdata_dev.rn and bibdata_prod.rb are identical at the moment.
@@ -32,7 +34,7 @@ Rails.application.configure do
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [:request_id]
-  config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
+  config.logger   = ActiveSupport::TaggedLogging.logger($stdout)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'error')

--- a/config/environments/folio_sync_dev.rb
+++ b/config/environments/folio_sync_dev.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require Rails.root.join('config/environments/deployed.rb')
 
 Rails.application.configure do

--- a/config/environments/folio_sync_prod.rb
+++ b/config/environments/folio_sync_prod.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require Rails.root.join('config/environments/deployed.rb')
 
 Rails.application.configure do

--- a/config/environments/folio_sync_test.rb
+++ b/config/environments/folio_sync_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require Rails.root.join('config/environments/deployed.rb')
 
 Rails.application.configure do

--- a/config/initializers/folio_sync.rb
+++ b/config/initializers/folio_sync.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Ensure that MARC download directory exists
+FileUtils.mkdir_p(Rails.configuration.folio_sync['marc_download_directory'])

--- a/config/templates/folio_sync.yml
+++ b/config/templates/folio_sync.yml
@@ -1,0 +1,5 @@
+development:
+  marc_download_directory: <%= Rails.root.join('tmp/development/downloaded_files') %>
+
+test:
+  marc_download_directory: <%= Rails.root.join('tmp/test/downloaded_files') %>

--- a/lib/folio_sync/archives_space/marc_exporter.rb
+++ b/lib/folio_sync/archives_space/marc_exporter.rb
@@ -10,10 +10,6 @@ module FolioSync
       def initialize
         @logger = Logger.new($stdout) # Ensure logger is initialized first
         @client = FolioSync::ArchivesSpace::Client.instance
-
-        # If directory doesn't exist, create it
-        download_directory = Rails.configuration.folio_sync['marc_download_directory']
-        FileUtils.mkdir_p(download_directory)
       end
 
       def export_recent_resources(modified_since = nil)

--- a/lib/folio_sync/archives_space/marc_exporter.rb
+++ b/lib/folio_sync/archives_space/marc_exporter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'fileutils'
 
 module FolioSync

--- a/lib/folio_sync/archives_space/marc_exporter.rb
+++ b/lib/folio_sync/archives_space/marc_exporter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'fileutils'
 
 module FolioSync
   module ArchivesSpace
@@ -8,6 +9,10 @@ module FolioSync
       def initialize
         @logger = Logger.new($stdout) # Ensure logger is initialized first
         @client = FolioSync::ArchivesSpace::Client.instance
+
+        # If directory doesn't exist, create it
+        download_directory = Rails.configuration.folio_sync['marc_download_directory']
+        FileUtils.mkdir_p(download_directory)
       end
 
       def export_recent_resources(modified_since = nil)
@@ -37,7 +42,7 @@ module FolioSync
         return @logger.error("No MARC found for repo #{repo_id} and resource_id #{resource_id}") unless marc_data
 
         # ! To check: other instances might use the same bib_id
-        file_path = Rails.root.join("tmp/marc_files/#{bib_id}.xml")
+        file_path = File.join(Rails.configuration.folio_sync['marc_download_directory'], "#{bib_id}.xml")
         File.binwrite(file_path, marc_data)
       end
 

--- a/lib/folio_sync/archives_space_to_folio/folio_synchronizer.rb
+++ b/lib/folio_sync/archives_space_to_folio/folio_synchronizer.rb
@@ -21,9 +21,9 @@ module FolioSync
       end
 
       def sync_resources_to_folio
-        # Iterate over all files in the tmp/marc_files directory
+        # Iterate over all files in the directory specified in the folio_sync.yml
         # Use foreach for better performance with large directories
-        marc_dir = Rails.root.join('tmp/marc_files')
+        marc_dir = Rails.configuration.folio_sync['marc_download_directory']
         folio_writer = FolioSync::Folio::Writer.new
 
         Dir.foreach(marc_dir) do |file|

--- a/lib/folio_sync/archives_space_to_folio/marc_record_enhancer.rb
+++ b/lib/folio_sync/archives_space_to_folio/marc_record_enhancer.rb
@@ -8,7 +8,7 @@ module FolioSync
       def initialize(bibid)
         @bibid = bibid
 
-        aspace_marc_path = Rails.root.join('tmp/marc_files', "#{bibid}.xml").to_s
+        aspace_marc_path = File.join(Rails.configuration.folio_sync['marc_download_directory'], "#{bibid}.xml")
         aspace_record = MARC::XMLReader.new(aspace_marc_path, parser: 'nokogiri')
 
         # TODO: If folio_record exists, update the 035 field

--- a/lib/tasks/folio_sync.rake
+++ b/lib/tasks/folio_sync.rake
@@ -11,9 +11,9 @@ namespace :folio_sync do
       puts 'Script completed successfully.'
     end
 
-    # Add a MARC XML test file to tmp/marc_files directory to verify the processing
+    # Add a MARC XML test file to the directory specified in folio_sync.yml
     # Run as:
-    # rake 'folio_sync:aspace_to_folio:process_marc_xml[<bib_id>]'
+    # bundle exec rake folio_sync:aspace_to_folio:process_marc_xml bib_id=<bib_id>'
     # ! Quotes are necessary to pass the argument correctly
     desc 'Process a MARC XML file for a given bib_id'
     task process_marc_xml: :environment do

--- a/spec/folio_sync/archives_space/marc_exporter_spec.rb
+++ b/spec/folio_sync/archives_space/marc_exporter_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe FolioSync::ArchivesSpace::MarcExporter do
     let(:resource_id) { '123' }
     let(:bib_id) { '456' }
     let(:marc_data) { '<record><controlfield tag="001">123456</controlfield></record>' }
-    let(:file_path) { Rails.root.join("tmp/marc_files/#{bib_id}.xml") }
+    let(:file_path) { File.join(Rails.configuration.folio_sync['marc_download_directory'], "#{bib_id}.xml") }
 
     before do
       allow(client).to receive(:fetch_marc_xml_resource).with(repo_id, resource_id).and_return(marc_data)

--- a/spec/folio_sync/archives_space_to_folio/folio_synchronizer_spec.rb
+++ b/spec/folio_sync/archives_space_to_folio/folio_synchronizer_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe FolioSync::ArchivesSpaceToFolio::FolioSynchronizer do
   end
 
   describe '#sync_resources_to_folio' do
-    let(:marc_dir) { Rails.root.join('tmp/marc_files') }
+    let(:marc_dir) { Rails.configuration.folio_sync['marc_download_directory'] }
     let(:files) { ['file1.xml', 'file2.xml'] }
     let(:enhancers) { files.map { instance_double(FolioSync::ArchivesSpaceToFolio::MarcRecordEnhancer) } }
     let(:marc_records) { enhancers.map { double('MARC::Record') } }

--- a/spec/folio_sync/archives_space_to_folio/marc_record_enhancer_spec.rb
+++ b/spec/folio_sync/archives_space_to_folio/marc_record_enhancer_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 
 RSpec.describe FolioSync::ArchivesSpaceToFolio::MarcRecordEnhancer do
   let(:bibid) { '123456' }
-  let(:marc_file_path) { Rails.root.join('tmp/marc_files', "#{bibid}.xml") }
+  let(:marc_file_path) do
+    File.join(Rails.configuration.folio_sync['marc_download_directory'], "#{bibid}.xml")
+  end
   let(:field_856_xml) do
     <<-XML
       <datafield tag="856" ind1="4" ind2="2">
@@ -35,9 +37,7 @@ RSpec.describe FolioSync::ArchivesSpaceToFolio::MarcRecordEnhancer do
   let(:mock_folio_record) { double('MARC::Record') }
 
   before do
-    # Ensure the tmp/marc_files directory exists
-    # And create a mock MARC file
-    FileUtils.mkdir_p(File.dirname(marc_file_path))
+    FileUtils.mkdir_p(Rails.configuration.folio_sync['marc_download_directory'])
     File.write(marc_file_path, mock_marc_xml)
 
     # Mock FOLIO::Reader

--- a/spec/folio_sync/archives_space_to_folio/marc_record_enhancer_spec.rb
+++ b/spec/folio_sync/archives_space_to_folio/marc_record_enhancer_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe FolioSync::ArchivesSpaceToFolio::MarcRecordEnhancer do
   let(:mock_folio_record) { double('MARC::Record') }
 
   before do
-    FileUtils.mkdir_p(Rails.configuration.folio_sync['marc_download_directory'])
     File.write(marc_file_path, mock_marc_xml)
 
     # Mock FOLIO::Reader


### PR DESCRIPTION
# Ticket [ASI-302](https://columbiauniversitylibraries.atlassian.net/browse/ASI-302)

Allows specifying a custom directory for saving MARC files. The directory will differ depending on the environment, allowing us to avoid collisions when running tests and other tasks.
The download directory will be set in the `folio_sync.yml` file and accessed through the `Rails.configuration` object.