### PR TITLE
ASPACE-306 Update id_0 and user defined fields

### DIFF
--- a/lib/folio_sync/archives_space/client.rb
+++ b/lib/folio_sync/archives_space/client.rb
@@ -68,12 +68,16 @@ class FolioSync::ArchivesSpace::Client < ArchivesSpace::Client
     response.parsed
   end
 
+  def update_resource(repo_id, resource_id, updated_data)
+    response = self.post("repositories/#{repo_id}/resources/#{resource_id}", updated_data)
+    handle_response(response, "Failed to update resource #{resource_id}")
+  end
+
   def update_id_0_field(repo_id, resource_id, new_id)
     old_resource = fetch_resource(repo_id, resource_id)
     updated_resource_data = old_resource.merge('id_0' => new_id)
 
-    response = self.post("repositories/#{repo_id}/resources/#{resource_id}", updated_resource_data)
-    handle_response(response, "Failed to update id_0 field for resource #{resource_id}")
+    update_resource(repo_id, resource_id, updated_resource_data)
   end
 
   def update_string_1_field(repo_id, resource_id, new_string)
@@ -82,8 +86,7 @@ class FolioSync::ArchivesSpace::Client < ArchivesSpace::Client
     user_defined['string_1'] = new_string
     updated_resource_data = old_resource.merge('user_defined' => user_defined)
 
-    response = self.post("repositories/#{repo_id}/resources/#{resource_id}", updated_resource_data)
-    handle_response(response, "Failed to update string_1 field for resource #{resource_id}")
+    update_resource(repo_id, resource_id, updated_resource_data)
   end
 
   private

--- a/lib/folio_sync/archives_space/client.rb
+++ b/lib/folio_sync/archives_space/client.rb
@@ -64,13 +64,26 @@ class FolioSync::ArchivesSpace::Client < ArchivesSpace::Client
 
   def fetch_resource(repo_id, resource_id)
     response = self.get("repositories/#{repo_id}/resources/#{resource_id}")
+    handle_response(response, "Failed to fetch resource #{resource_id}")
     response.parsed
   end
 
-  def update_id_0_field_for_resource(repo_id, resource_id, new_id)
+  def update_id_0_field(repo_id, resource_id, new_id)
     old_resource = fetch_resource(repo_id, resource_id)
     updated_resource_data = old_resource.merge('id_0' => new_id)
-    self.post("repositories/#{repo_id}/resources/#{resource_id}", updated_resource_data)
+
+    response = self.post("repositories/#{repo_id}/resources/#{resource_id}", updated_resource_data)
+    handle_response(response, "Failed to update id_0 field for resource #{resource_id}")
+  end
+
+  def update_string_1_field(repo_id, resource_id, new_string)
+    old_resource = fetch_resource(repo_id, resource_id)
+    user_defined = old_resource['user_defined'] || {}
+    user_defined['string_1'] = new_string
+    updated_resource_data = old_resource.merge('user_defined' => user_defined)
+
+    response = self.post("repositories/#{repo_id}/resources/#{resource_id}", updated_resource_data)
+    handle_response(response, "Failed to update string_1 field for resource #{resource_id}")
   end
 
   private

--- a/lib/folio_sync/archives_space/client.rb
+++ b/lib/folio_sync/archives_space/client.rb
@@ -62,6 +62,17 @@ class FolioSync::ArchivesSpace::Client < ArchivesSpace::Client
     response.body
   end
 
+  def fetch_resource(repo_id, resource_id)
+    response = self.get("repositories/#{repo_id}/resources/#{resource_id}")
+    response.parsed
+  end
+
+  def update_id_0_field_for_resource(repo_id, resource_id, new_id)
+    old_resource = fetch_resource(repo_id, resource_id)
+    updated_resource_data = old_resource.merge('id_0' => new_id)
+    self.post("repositories/#{repo_id}/resources/#{resource_id}", updated_resource_data)
+  end
+
   private
 
   def handle_response(response, error_message)

--- a/lib/tasks/folio_sync.rake
+++ b/lib/tasks/folio_sync.rake
@@ -165,8 +165,8 @@ namespace :folio_sync do
 
     task update_string_1: :environment do
       FolioSync::Rake::EnvValidator.validate!(
-        ['instance_key', 'repo_id', 'resource_id', 'new_id'],
-        'bundle exec rake folio_sync:aspace_to_folio:update_string_1 instance_key=cul repo_id=1 resource_id=123 new_id=123'
+        ['instance_key', 'repo_id', 'resource_id', 'new_string'],
+        'bundle exec rake folio_sync:aspace_to_folio:update_string_1 instance_key=cul repo_id=1 resource_id=123 new_string=abc'
       )
       instance_key = ENV['instance_key']
 
@@ -177,10 +177,10 @@ namespace :folio_sync do
 
       repo_id = ENV['repo_id']
       resource_id = ENV['resource_id']
-      new_id = ENV['new_id']
+      new_string = ENV['new_string']
 
       aspace_client = FolioSync::ArchivesSpace::Client.new(instance_key)
-      aspace_client.update_string_1_field(repo_id, resource_id, new_id)
+      aspace_client.update_string_1_field(repo_id, resource_id, new_string)
     end
   end
 end

--- a/lib/tasks/folio_sync.rake
+++ b/lib/tasks/folio_sync.rake
@@ -143,17 +143,44 @@ namespace :folio_sync do
       ).folio_sync_error_email.deliver
     end
 
-    task update_id: :environment do
+    task update_id_0: :environment do
+      FolioSync::Rake::EnvValidator.validate!(
+        ['instance_key', 'repo_id', 'resource_id', 'new_id'],
+        'bundle exec rake folio_sync:aspace_to_folio:update_id_0 instance_key=cul repo_id=1 resource_id=123 new_id=123'
+      )
       instance_key = ENV['instance_key']
 
-      unless instance_key
-        puts 'Error: Please provide an instance_key.'
-        puts 'Usage: bundle exec rake folio_sync:aspace_to_folio:run instance_key=cul'
-        exit 1
+      if instance_key == 'barnard'
+        puts "Temporarily disabling writing to Barnard's ArchivesSpace instance"
+        exit(1)
       end
 
+      repo_id = ENV['repo_id']
+      resource_id = ENV['resource_id']
+      new_id = ENV['new_id']
+
       aspace_client = FolioSync::ArchivesSpace::Client.new(instance_key)
-      aspace_client.update_id_0_field_for_resource(2, 6330, '111111111111')
+      aspace_client.update_id_0_field(repo_id, resource_id, new_id)
+    end
+
+    task update_string_1: :environment do
+      FolioSync::Rake::EnvValidator.validate!(
+        ['instance_key', 'repo_id', 'resource_id', 'new_id'],
+        'bundle exec rake folio_sync:aspace_to_folio:update_string_1 instance_key=cul repo_id=1 resource_id=123 new_id=123'
+      )
+      instance_key = ENV['instance_key']
+
+      if instance_key == 'barnard'
+        puts "Temporarily disabling writing to Barnard's ArchivesSpace instance"
+        exit(1)
+      end
+
+      repo_id = ENV['repo_id']
+      resource_id = ENV['resource_id']
+      new_id = ENV['new_id']
+
+      aspace_client = FolioSync::ArchivesSpace::Client.new(instance_key)
+      aspace_client.update_string_1_field(repo_id, resource_id, new_id)
     end
   end
 end

--- a/lib/tasks/folio_sync.rake
+++ b/lib/tasks/folio_sync.rake
@@ -134,5 +134,18 @@ namespace :folio_sync do
         ]
       ).folio_sync_error_email.deliver
     end
+
+    task update_id: :environment do
+      instance_key = ENV['instance_key']
+
+      unless instance_key
+        puts 'Error: Please provide an instance_key.'
+        puts 'Usage: bundle exec rake folio_sync:aspace_to_folio:run instance_key=cul'
+        exit 1
+      end
+
+      aspace_client = FolioSync::ArchivesSpace::Client.new(instance_key)
+      aspace_client.update_id_0_field_for_resource(2, 6330, '111111111111')
+    end
   end
 end

--- a/spec/folio_sync/archives_space/client_spec.rb
+++ b/spec/folio_sync/archives_space/client_spec.rb
@@ -254,6 +254,33 @@ RSpec.describe FolioSync::ArchivesSpace::Client do
     end
   end
 
+  describe '#update_resource' do
+    let(:instance) { described_class.new(instance_key) }
+    let(:updated_data) { { 'id_0' => '456', 'title' => 'Updated Resource' } }
+    let(:response) { instance_double('Response') }
+
+    before do
+      allow(instance).to receive(:post).with("repositories/#{repository_id}/resources/#{resource_id}",
+                                             updated_data).and_return(response)
+      allow(response).to receive(:status_code).and_return(200)
+    end
+
+    it 'updates the resource with the given data' do
+      instance.update_resource(repository_id, resource_id, updated_data)
+      expect(instance).to have_received(:post).with("repositories/#{repository_id}/resources/#{resource_id}",
+                                                    updated_data)
+    end
+
+    it 'raises an error if the response status code is not 200' do
+      allow(response).to receive_messages(status_code: 500, body: 'Internal Server Error')
+
+      expect {
+        instance.update_resource(repository_id, resource_id, updated_data)
+      }.to raise_error(FolioSync::Exceptions::ArchivesSpaceRequestError,
+                       'Failed to update resource 4656: Internal Server Error')
+    end
+  end
+
   describe '#update_id_0_field' do
     let(:instance) { described_class.new(instance_key) }
     let(:old_resource) { { 'id_0' => '123', 'title' => 'Test Resource' } }
@@ -280,7 +307,7 @@ RSpec.describe FolioSync::ArchivesSpace::Client do
       expect {
         instance.update_id_0_field(repository_id, resource_id, new_id)
       }.to raise_error(FolioSync::Exceptions::ArchivesSpaceRequestError,
-                       'Failed to update id_0 field for resource 4656: Internal Server Error')
+                       'Failed to update resource 4656: Internal Server Error')
     end
   end
 
@@ -311,7 +338,7 @@ RSpec.describe FolioSync::ArchivesSpace::Client do
       expect {
         instance.update_string_1_field(repository_id, resource_id, new_string)
       }.to raise_error(FolioSync::Exceptions::ArchivesSpaceRequestError,
-                       'Failed to update string_1 field for resource 4656: Internal Server Error')
+                       'Failed to update resource 4656: Internal Server Error')
     end
   end
 end


### PR DESCRIPTION
# Ticket [ASPACE-306](https://columbiauniversitylibraries.atlassian.net/browse/ASPACE-306)

## Overview
This PR adds methods for updating fields on ArchivesSpace resources. These methods will be used later for storing FOLIO's HRID.

#### Methods added
- `fetch_resource`
- `update_resource`
- Field-specific: `update_id_0_field` and `update_string_1_field`

#### Rake tasks added for testing
- `folio_sync:aspace_to_folio:update_id_0` 
- `folio_sync:aspace_to_folio:update_string_1`