### PR TITLE
ASPACE-306 Modify ASpace method to update the ead_id field

### DIFF
--- a/lib/folio_sync/archives_space/client.rb
+++ b/lib/folio_sync/archives_space/client.rb
@@ -73,9 +73,9 @@ class FolioSync::ArchivesSpace::Client < ArchivesSpace::Client
     handle_response(response, "Failed to update resource #{resource_id}")
   end
 
-  def update_id_0_field(repo_id, resource_id, new_id)
+  def update_id_fields(repo_id, resource_id, new_id)
     old_resource = fetch_resource(repo_id, resource_id)
-    updated_resource_data = old_resource.merge('id_0' => new_id)
+    updated_resource_data = old_resource.merge('id_0' => new_id, 'ead_id' => new_id)
 
     update_resource(repo_id, resource_id, updated_resource_data)
   end

--- a/lib/tasks/folio_sync.rake
+++ b/lib/tasks/folio_sync.rake
@@ -144,10 +144,10 @@ namespace :folio_sync do
       ).folio_sync_error_email.deliver
     end
 
-    task update_id_0: :environment do
+    task update_ids: :environment do
       FolioSync::Rake::EnvValidator.validate!(
         ['instance_key', 'repo_id', 'resource_id', 'new_id'],
-        'bundle exec rake folio_sync:aspace_to_folio:update_id_0 instance_key=cul repo_id=1 resource_id=123 new_id=123'
+        'bundle exec rake folio_sync:aspace_to_folio:update_ids instance_key=cul repo_id=1 resource_id=123 new_id=123'
       )
       instance_key = ENV['instance_key']
 
@@ -161,7 +161,7 @@ namespace :folio_sync do
       new_id = ENV['new_id']
 
       aspace_client = FolioSync::ArchivesSpace::Client.new(instance_key)
-      aspace_client.update_id_0_field(repo_id, resource_id, new_id)
+      aspace_client.update_id_fields(repo_id, resource_id, new_id)
     end
 
     task update_string_1: :environment do

--- a/spec/folio_sync/archives_space/client_spec.rb
+++ b/spec/folio_sync/archives_space/client_spec.rb
@@ -282,22 +282,22 @@ RSpec.describe FolioSync::ArchivesSpace::Client do
     end
   end
 
-  describe '#update_id_0_field' do
+  describe '#update_id_fields' do
     let(:instance) { described_class.new(instance_key) }
-    let(:old_resource) { { 'id_0' => '123', 'title' => 'Test Resource' } }
+    let(:old_resource) { { 'id_0' => '123', 'ead_id' => '123', 'title' => 'Test Resource' } }
     let(:new_id) { '456' }
-    let(:updated_resource_data) { old_resource.merge('id_0' => new_id) }
+    let(:updated_resource_data) { old_resource.merge('id_0' => new_id, 'ead_id' => new_id) }
     let(:response) { instance_double('Response') }
 
     before do
       allow(instance).to receive(:fetch_resource).with(repository_id, resource_id).and_return(old_resource)
       allow(instance).to receive(:post).with("repositories/#{repository_id}/resources/#{resource_id}",
-                                             updated_resource_data).and_return(response)
+                                           updated_resource_data).and_return(response)
       allow(response).to receive(:status_code).and_return(200)
     end
 
-    it 'updates the id_0 field of the resource' do
-      instance.update_id_0_field(repository_id, resource_id, new_id)
+    it 'updates both id_0 and ead_id fields of the resource' do
+      instance.update_id_fields(repository_id, resource_id, new_id)
       expect(instance).to have_received(:post).with("repositories/#{repository_id}/resources/#{resource_id}",
                                                     updated_resource_data)
     end
@@ -306,7 +306,7 @@ RSpec.describe FolioSync::ArchivesSpace::Client do
       allow(response).to receive_messages(status_code: 500, body: 'Internal Server Error')
 
       expect {
-        instance.update_id_0_field(repository_id, resource_id, new_id)
+        instance.update_id_fields(repository_id, resource_id, new_id)
       }.to raise_error(FolioSync::Exceptions::ArchivesSpaceRequestError,
                        'Failed to update resource 4656: Internal Server Error')
     end


### PR DESCRIPTION
# Ticket [ASPACE-306](https://columbiauniversitylibraries.atlassian.net/browse/ASPACE-306) 

## Overview
This is a minor update to an existing logic captured in ASPACE-306 (the previous PR was merged [here](https://github.com/cul/folio_sync/pull/10)). When updating ArchivesSpace records, we want to update not only `id_0` but `ead_id` as well (using the same value).

Note: These methods are currently not being used anywhere (except for testing rake tasks) and may change in the future, as we have made some assumptions about the behavior of FOLIO's HRIDs.