### PR TITLE
ASPACE-317 Perform lookup by hrid, send email notification when db is invalid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ coverage
 
 # Ignore local rake tasks
 /lib/tasks/local.rake
+/lib/tasks/test_create_or_update.rake

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -29,6 +29,29 @@ class ApplicationMailer < ActionMailer::Base
     }
   ].freeze
 
+  def folio_sync_database_error_email
+    body_content = <<~EMAIL
+      The FOLIO Sync script has been interrupted due to a database integrity issue.
+
+      One or more database records were found with missing folio_hrid values. To prevent the creation of duplicate entries in FOLIO, the synchronization process has been halted.
+
+      Please investigate the following:
+      1. Review recent synchronization logs for any errors or interruptions
+      2. Check database records with nil folio_hrid values for instance: #{params[:instance_key]}
+      3. Determine if records need to be manually corrected or re-synchronized
+      4. Restart the sync process only after resolving the underlying issue
+
+      This is an automated notification.
+    EMAIL
+
+    mail(
+      to: params[:to],
+      subject: params[:subject],
+      body: body_content,
+      content_type: 'text/plain'
+    )
+  end
+
   def folio_sync_error_email
     error_sections = ERROR_TYPES.map do |type|
       {

--- a/app/models/aspace_to_folio_record.rb
+++ b/app/models/aspace_to_folio_record.rb
@@ -8,17 +8,22 @@ class AspaceToFolioRecord < ApplicationRecord
   validates :resource_key, presence: true
 
   def self.create_or_update_from_data(data)
-    record = find_or_initialize_by(
-      archivesspace_instance_key: data[:archivesspace_instance_key],
-      repository_key: data[:repository_key],
-      resource_key: data[:resource_key]
-    )
+    if data[:folio_hrid].present?
+      existing_record = find_by(folio_hrid: data[:folio_hrid])
 
-    record.folio_hrid = data[:folio_hrid] if data.key?(:folio_hrid)
-    record.pending_update = data[:pending_update] if data.key?(:pending_update)
-    record.is_folio_suppressed = data[:is_folio_suppressed] if data.key?(:is_folio_suppressed)
+      if existing_record
+        # Update the existing record with only pending_update and is_folio_suppressed
+        # Other fields remain unchanged
+        existing_record.update!(
+          pending_update: data[:pending_update],
+          is_folio_suppressed: data[:is_folio_suppressed]
+        )
+        return existing_record
+      end
+    end
 
-    record.save!
+    # Create a new record with all the data (either folio_hrid is nil or there is no existing record)
+    create!(data)
   end
 
   def archivesspace_marc_xml_path

--- a/app/models/aspace_to_folio_record.rb
+++ b/app/models/aspace_to_folio_record.rb
@@ -12,12 +12,14 @@ class AspaceToFolioRecord < ApplicationRecord
       existing_record = find_by(folio_hrid: data[:folio_hrid])
 
       if existing_record
-        # Update the existing record with only pending_update and is_folio_suppressed
+        # Update the existing record with pending_update, is_folio_suppressed and folio_hrid
         # Other fields remain unchanged
-        existing_record.update!(
-          pending_update: data[:pending_update],
-          is_folio_suppressed: data[:is_folio_suppressed]
-        )
+        update_attributes = {}
+        update_attributes[:pending_update] = data[:pending_update] if data.key?(:pending_update)
+        update_attributes[:is_folio_suppressed] = data[:is_folio_suppressed] if data.key?(:is_folio_suppressed)
+        update_attributes[:folio_hrid] = data[:folio_hrid] if data.key?(:folio_hrid)
+
+        existing_record.update!(update_attributes)
         return existing_record
       end
     end

--- a/lib/folio_sync/archives_space_to_folio/folio_synchronizer.rb
+++ b/lib/folio_sync/archives_space_to_folio/folio_synchronizer.rb
@@ -14,6 +14,8 @@ module FolioSync
       end
 
       def fetch_and_sync_aspace_to_folio_records(last_x_hours)
+        database_valid?
+
         modified_since = Time.now.utc - (ONE_HOUR_IN_SECONDS * last_x_hours) if last_x_hours
 
         # 1. Fetch resources from ArchivesSpace based on their modification time and save them to the database
@@ -91,6 +93,27 @@ module FolioSync
 
         @logger.error("Errors encountered during ArchivesSpace updates: #{updater.updating_errors}")
         @linking_errors = updater.updating_errors
+      end
+
+      # If any of the records in the database has its folio_hrid set to nil,
+      # we assume the database is not valid
+      def database_valid?
+        if AspaceToFolioRecord.exists?(
+          archivesspace_instance_key: @instance_key,
+          folio_hrid: nil
+        )
+
+          ApplicationMailer.with(
+            to: Rails.configuration.folio_sync[:aspace_to_folio][:developer_email_address],
+            subject: "FOLIO Sync failed to validate database for #{@instance_key}",
+            instance_key: @instance_key
+          ).folio_sync_database_error_email.deliver
+
+          raise "Database is not valid for instance #{@instance_key}."
+        end
+
+        @logger.info("Database is valid for instance #{@instance_key}.")
+        true
       end
 
       def clear_downloads!

--- a/lib/folio_sync/archives_space_to_folio/folio_synchronizer.rb
+++ b/lib/folio_sync/archives_space_to_folio/folio_synchronizer.rb
@@ -129,6 +129,7 @@ module FolioSync
         @downloading_errors = []
         @saving_errors = []
         @fetching_errors = []
+        @linking_errors = []
       end
     end
   end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -32,6 +32,36 @@ RSpec.describe ApplicationMailer, type: :mailer do
     ]
   end
 
+  describe '#folio_sync_database_error_email' do
+    before do
+      allow(described_class).to receive(:default).and_return(from: 'test-email@example.com')
+    end
+
+    let(:mail) do
+      described_class.with(
+        to: to_email,
+        subject: mail_subject,
+        instance_key: 'test_instance_key'
+      ).folio_sync_database_error_email
+    end
+
+    it 'renders the correct subject' do
+      expect(mail.subject).to eq(mail_subject)
+    end
+
+    it 'sends the email to the correct recipient' do
+      expect(mail.to).to eq([to_email])
+    end
+
+    it 'sets the correct sender email' do
+      expect(mail.from).to eq(['test-email@example.com'])
+    end
+
+    it 'includes the instance key in the email body' do
+      expect(mail.body.encoded).to include('test_instance_key')
+    end
+  end
+
   describe '#folio_sync_error_email' do
     before do
       allow(described_class).to receive(:default).and_return(from: 'test-email@example.com')

--- a/spec/models/aspace_to_folio_record_spec.rb
+++ b/spec/models/aspace_to_folio_record_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe AspaceToFolioRecord, type: :model do
       {
         archivesspace_instance_key: 'test_instance',
         repository_key: 2,
-        resource_key: 123
+        resource_key: 123,
+        folio_hrid: 'test_hrid',
       }
     end
 
@@ -57,6 +58,7 @@ RSpec.describe AspaceToFolioRecord, type: :model do
         expect(record.resource_key).to eq(123)
         expect(record.pending_update).to eq('no_update')
         expect(record.is_folio_suppressed).to be true
+        expect(record.folio_hrid).to eq('test_hrid')
       end
 
       it 'creates a record with only required fields when optional fields are not provided' do
@@ -67,33 +69,41 @@ RSpec.describe AspaceToFolioRecord, type: :model do
         expect(record.archivesspace_instance_key).to eq('test_instance')
         expect(record.repository_key).to eq(2)
         expect(record.resource_key).to eq(123)
-        expect(record.folio_hrid).to be_nil
         expect(record.pending_update).to eq('to_folio') # default value is 'to_folio'
         expect(record.is_folio_suppressed).to be false # default value from schema
       end
     end
 
     context 'when updating an existing record' do
-      let!(:existing_record) { FactoryBot.create(:aspace_to_folio_record, base_data.merge(folio_hrid: 'old_hrid', pending_update: 'no_update', is_folio_suppressed: false)) }
+      let!(:existing_record) { 
+        FactoryBot.create(:aspace_to_folio_record, 
+                         pending_update: 'no_update', 
+                         is_folio_suppressed: false, 
+                         folio_hrid: 'old_hrid') 
+      }
 
       it 'updates the existing record with new data' do
-        data = base_data.merge(
-          folio_hrid: 'new_hrid',
+        data = {
           pending_update: 'to_aspace',
-          is_folio_suppressed: true
-        )
+          is_folio_suppressed: true,
+          folio_hrid: 'old_hrid' # Use the existing folio_hrid to find the record
+        }
 
         expect { AspaceToFolioRecord.create_or_update_from_data(data) }
           .not_to change(AspaceToFolioRecord, :count)
 
         existing_record.reload
-        expect(existing_record.folio_hrid).to eq('new_hrid')
+        expect(existing_record.folio_hrid).to eq('old_hrid')
         expect(existing_record.pending_update).to eq('to_aspace')
         expect(existing_record.is_folio_suppressed).to be true
       end
 
       it 'does not update fields that are not present in the data hash' do
-        expect { AspaceToFolioRecord.create_or_update_from_data(base_data) }
+        data = {
+          folio_hrid: 'old_hrid' # Use the existing folio_hrid to find the record
+        }
+
+        expect { AspaceToFolioRecord.create_or_update_from_data(data) }
           .not_to change(AspaceToFolioRecord, :count)
 
         existing_record.reload

--- a/spec/models/aspace_to_folio_record_spec.rb
+++ b/spec/models/aspace_to_folio_record_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe AspaceToFolioRecord, type: :model do
     context 'when creating a new record' do
       it 'creates a new record with the provided data' do
         data = base_data.merge(
-          folio_hrid: 'test_hrid',
           pending_update: 'no_update',
           is_folio_suppressed: true
         )
@@ -56,7 +55,6 @@ RSpec.describe AspaceToFolioRecord, type: :model do
         expect(record.archivesspace_instance_key).to eq('test_instance')
         expect(record.repository_key).to eq(2)
         expect(record.resource_key).to eq(123)
-        expect(record.folio_hrid).to eq('test_hrid')
         expect(record.pending_update).to eq('no_update')
         expect(record.is_folio_suppressed).to be true
       end


### PR DESCRIPTION
# Ticket [ASPACE-317](https://columbiauniversitylibraries.atlassian.net/browse/ASPACE-317)

## Overview
This PR:
1. Modifies how we create/update database entries when we fetch resources from ArchivesSpace
2. Stops the script and sends an email notification when the database contains folio_hrid that are nil

### Updated `create_or_update_from_data` method
Previously, when determining if a database record should be created or updated, we relied on the combination of `archivesspace_instance_key`, `repository_key` and `resource_key`. However, every time the FOLIO script runs (successfully), all the database entries should have a unique `folio_hrid` that we can use for lookups. Using these IDs improves the script's performance since we can rely on one value instead of 3.

### Sending an email notification if the database records contain empty folio_hrids
Related to the behavior above, we need to make sure we can trust the database and rely on non-empty hrids to prevent creating duplicate FOLIO records. To do that, we'll interrupt the script if we find any errors with missing hrids and send an email notification.