### PR TITLE
ASPACE-318 replace search endpoint with resources endpoint when build…

### DIFF
--- a/lib/folio_sync/archives_space/client.rb
+++ b/lib/folio_sync/archives_space/client.rb
@@ -50,8 +50,16 @@ class FolioSync::ArchivesSpace::Client < ArchivesSpace::Client
     end
   end
 
-  # This method is used only for a one-time manual step
-  # to identify which ASpace resources have corresponding FOLIO records.
+  # This method fetches all resources for a given repository
+  # and yields them to the block for processing.
+  # It handles pagination automatically.
+  #
+  # @param repo_id [String] The ID of the repository to fetch resources from.
+  # @param query_params [Hash] The query parameters for the API request.
+  #
+  # @yield [Array] The array of resources fetched from the API.
+  #
+  # @return [void]
   def retrieve_resources_for_repository(repo_id, query_params)
     query = query_params.dup
     query[:page] ||= 1

--- a/lib/folio_sync/archives_space_to_folio/folio_synchronizer.rb
+++ b/lib/folio_sync/archives_space_to_folio/folio_synchronizer.rb
@@ -29,7 +29,11 @@ module FolioSync
       end
 
       def fetch_archivesspace_resources(modified_since)
-        @logger.info("Fetching ArchivesSpace resources modified since: #{modified_since}")
+        if modified_since
+          @logger.info("Fetching ArchivesSpace resources modified since: #{modified_since.utc} (#{modified_since.to_i})")
+        else
+          @logger.info('Fetching all ArchivesSpace resources (no time filter)')
+        end
 
         fetcher = FolioSync::ArchivesSpace::ResourceFetcher.new(@instance_key)
         fetcher.fetch_and_save_recent_resources(modified_since)

--- a/spec/folio_sync/archives_space/resource_fetcher_spec.rb
+++ b/spec/folio_sync/archives_space/resource_fetcher_spec.rb
@@ -75,15 +75,13 @@ RSpec.describe FolioSync::ArchivesSpace::ResourceFetcher do
 
     it 'builds query parameters with a modification time filter' do
       instance = described_class.new(instance_key)
-      allow(instance).to receive(:time_to_solr_date_format).with(modified_since).and_return('2023-01-01T00:00:00.000Z')
 
       result = instance.send(:build_query_params, modified_since)
 
       expect(result).to eq({
-        q: 'primary_type:resource suppressed:false system_mtime:[2023-01-01T00:00:00.000Z TO *]',
         page: 1,
         page_size: described_class::PAGE_SIZE,
-        fields: %w[id identifier system_mtime title publish json]
+        modified_since: modified_since.to_i
       })
     end
 
@@ -92,20 +90,9 @@ RSpec.describe FolioSync::ArchivesSpace::ResourceFetcher do
       result = instance.send(:build_query_params, nil)
 
       expect(result).to eq({
-        q: 'primary_type:resource suppressed:false',
         page: 1,
-        page_size: described_class::PAGE_SIZE,
-        fields: %w[id identifier system_mtime title publish json]
+        page_size: described_class::PAGE_SIZE
       })
-    end
-  end
-
-  describe '#time_to_solr_date_format' do
-    it 'formats time correctly for Solr' do
-      instance = described_class.new(instance_key)
-      time = Time.utc(2023, 1, 1, 12, 30, 45, 123_000)
-      result = instance.send(:time_to_solr_date_format, time)
-      expect(result).to eq('2023-01-01T12:30:45.123Z')
     end
   end
 
@@ -129,12 +116,12 @@ RSpec.describe FolioSync::ArchivesSpace::ResourceFetcher do
   end
 
   describe '#log_resource_processing' do
-    let(:resource) { { 'title' => 'Test Resource', 'id' => '123' } }
+    let(:resource) { { 'title' => 'Test Resource', 'uri' => '/repositories/1/resources/123' } }
 
     it 'logs resource processing message' do
       instance = described_class.new(instance_key)
       instance.send(:log_resource_processing, resource)
-      expect(logger).to have_received(:info).with('Processing resource: Test Resource (ID: 123)')
+      expect(logger).to have_received(:info).with('Processing resource: Test Resource (URI: /repositories/1/resources/123)')
     end
   end
 end


### PR DESCRIPTION
# Ticket [ASPACE-318](https://columbiauniversitylibraries.atlassian.net/browse/ASPACE-318)

## Overview
Modifies ASpace resource fetching logic to use the `repositories/#{repo_id}/resources` endpoint instead of the SOLR-dependent `repositories/#{repo_id}/search` endpoint to avoid delays with indexing.