### PR TITLE
FOLIOSYNC-17: Clear id_1, id_2 and id_3 values when modifying ASpace records

### DIFF
--- a/lib/folio_sync/archives_space/resource_updater.rb
+++ b/lib/folio_sync/archives_space/resource_updater.rb
@@ -57,6 +57,9 @@ module FolioSync
         update_resource_with_folio_data(record.repository_key, record.resource_key) do |resource_data|
           resource_data.merge(
             'id_0' => record.folio_hrid,
+            'id_1' => '',
+            'id_2' => '',
+            'id_3' => '',
             'ead_id' => record.folio_hrid
           )
         end

--- a/spec/folio_sync/archives_space/resource_updater_spec.rb
+++ b/spec/folio_sync/archives_space/resource_updater_spec.rb
@@ -89,6 +89,22 @@ RSpec.describe FolioSync::ArchivesSpace::ResourceUpdater do
       expect(updater).to receive(:update_resource_with_folio_data).with(1, 123)
       updater.update_id_fields(record)
     end
+
+    it 'clears id_1, id_2, and id_3 while setting id_0 and ead_id to folio_hrid' do
+      updater = described_class.new('cul')
+      resource_data = { 'id_0' => 'old', 'id_1' => 'part1', 'id_2' => 'part2', 'id_3' => 'part3' }
+
+      allow(client).to receive(:fetch_resource).with(1, 123).and_return(resource_data)
+      expect(client).to receive(:update_resource) do |_repo_id, _res_id, data|
+        expect(data['id_0']).to eq('hrid1')
+        expect(data['ead_id']).to eq('hrid1')
+        expect(data['id_1']).to eq('')
+        expect(data['id_2']).to eq('')
+        expect(data['id_3']).to eq('')
+      end
+
+      updater.update_id_fields(record)
+    end
   end
 
   describe '#update_string_1_field' do


### PR DESCRIPTION
# Ticket [FOLIOSYNC-17](https://columbiauniversitylibraries.atlassian.net/browse/FOLIOSYNC-17)

Clears `id_1`, `id_2`, and `id_3` identifier values when modifying ArchivesSpace records. Sending empty values is the same as deleting the key, so we’re effectively deleting all identifiers, except `id_0` (which stores the new FOLIO hrid).